### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/katasu-me/katasu.me/security/code-scanning/3](https://github.com/katasu-me/katasu.me/security/code-scanning/3)

The best way to fix this is to add a `permissions` block specifying least privilege at the appropriate level. Since the job is named `test` and does not appear to perform any actions requiring more than read access to repository contents, you should set `permissions: contents: read` for either the workflow as a whole or, for greatest clarity and reduction of blast radius, directly on the job.
To implement the fix, add a `permissions:` line with appropriate indentation under the relevant level (`jobs: test:` in this case, since that's closest to the error). No changes to other code, imports, or actions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
