### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy to Cloudflare Workers
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/katasu-me/katasu.me/security/code-scanning/2](https://github.com/katasu-me/katasu.me/security/code-scanning/2)

To resolve the issue, explicitly set the `permissions` block at the workflow or job level to restrict GITHUB_TOKEN privileges to the minimum necessary. In this workflow, no steps appear to require write access to code, issues, or pull requests. The minimum safe permission is `contents: read`. The block should be added at the root (top-level, alongside `name` and `on`), to apply to all jobs in the workflow, unless specific jobs need different permissions. No other changes, imports, or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
