### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/katasu-me/katasu.me/security/code-scanning/1](https://github.com/katasu-me/katasu.me/security/code-scanning/1)

To fix this problem, add an explicit `permissions:` block to the workflow, restricting the `GITHUB_TOKEN` to only the minimum privilege needed. In this case, the workflow does not push, open PRs, or interact with issues, so `contents: read` is sufficient.  
The best way to do this is to add a `permissions:` block with `contents: read` at the top level of the workflow YAML, just below the `name:` entry and before `on:`. This will apply to all jobs unless a job explicitly overrides it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
