### PR TITLE
feat: add global 404 page

### DIFF
--- a/apps/service/src/app/not-found.tsx
+++ b/apps/service/src/app/not-found.tsx
@@ -1,8 +1,8 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import Link from "next/link";
 import LogoImage from "@/assets/logo.svg";
-import Button from "@/components/Button";
 import BudouX from "@/components/BudouX";
+import Button from "@/components/Button";
 import { generateMetadataTitle } from "@/lib/meta";
 
 export const metadata: Metadata = generateMetadataTitle({ pageTitle: "お探しのページが見つかりません" });
@@ -11,16 +11,14 @@ export default function NotFound() {
   return (
     <div className="col-start-2 flex min-h-screen flex-col items-center justify-center">
       <section className="flex flex-col items-center justify-center text-center">
-        <LogoImage className="w-32 pc:w-48 opacity-70" />
-        <h1 className="mt-8 text-2xl pc:text-3xl font-normal tracking-[0.1em] text-warm-black">
-          404
-        </h1>
-        <div className="mt-4 text-warm-black-50 leading-[1.6] tracking-[0.04em]">
+        <LogoImage className="pc:w-48 w-32 opacity-70" />
+        <h1 className="mt-8 font-normal pc:text-3xl text-2xl text-warm-black tracking-[0.1em]">404</h1>
+        <div className="mt-4 text-warm-black">
           <p>
-            <BudouX>お探しのページが見つかりません。</BudouX>
+            <BudouX>ページが見つかりませんでした。</BudouX>
           </p>
           <p className="mt-2">
-            <BudouX>ページが移動されたか、削除された可能性があります。</BudouX>
+            <BudouX>ページが移動されたか、削除されたのかもしれません。</BudouX>
           </p>
         </div>
         <Link href="/" className="mt-8">


### PR DESCRIPTION
## Summary
- Create global 404 page for Next.js App Router
- Follow existing design patterns and component structure
- Include proper Japanese text handling with BudouX

## Changes
- Add `apps/service/src/app/not-found.tsx`
- Use existing Logo, Button, and BudouX components
- Implement responsive design with proper spacing
- Include SEO-friendly metadata

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)